### PR TITLE
Add deprecation warning for ConfigMap-based remediation

### DIFF
--- a/pkg/handlers/alerts.go
+++ b/pkg/handlers/alerts.go
@@ -78,7 +78,10 @@ func (s *Server) AlertsPostHandler(w http.ResponseWriter, r *http.Request) {
 		// New CRD-based approach
 		s.handleOperariusBasedJobs(r.Context(), message)
 	} else {
-		// Legacy ConfigMap-based approach
+		// Legacy ConfigMap-based approach - DEPRECATED in v0.17.0, will be removed in v0.18.0
+		log.Warn("DEPRECATION: ConfigMap-based remediation is deprecated and will be removed in v0.18.0. Please migrate to Operarius CRDs. See docs/operarius-crd-migration.md for migration guide.",
+			zap.String("alertname", message.CommonLabels["alertname"]),
+			zap.String("groupKey", message.GroupKey))
 		log.Debug("Creating response jobs (legacy mode)",
 			zap.Int("jobCount", alertcount),
 			zap.String("groupKey", message.GroupKey))


### PR DESCRIPTION
## Summary

Adds a runtime deprecation warning when the legacy ConfigMap-based remediation path is used.

## Changes

- Added `log.Warn()` call in `pkg/handlers/alerts.go` that triggers on every webhook when using ConfigMap mode
- Warning includes clear deprecation timeline (removal in v0.18.0)
- References migration documentation (`docs/operarius-crd-migration.md`)
- Includes alert context (alertname, groupKey) for troubleshooting

## Migration Context

This is part of the v0.17.0 release preparation:

| Version | ConfigMap Status | CRD Status |
|---------|------------------|------------|
| v0.16.x | Default | Optional |
| **v0.17.0** | **Deprecated (warning)** | **Default** |
| v0.18.0 | Removed | Only option |

## Example Log Output

```
WARN: DEPRECATION: ConfigMap-based remediation is deprecated and will be removed in v0.18.0. Please migrate to Operarius CRDs. See docs/operarius-crd-migration.md for migration guide. {"alertname": "KubePodCrashLooping", "groupKey": "..."}
```

## Testing

- [x] `go build` successful
- [x] `go test ./...` all tests pass