### PR TITLE
ci: harden Go workflow and re-enable Go linting in super-linter

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-e2e:
     name: Run on Ubuntu

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-changes:
     name: Check for Frontend changes

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: read
 
+# Cancel in-progress runs for the same PR/branch when a new commit is pushed.
+# On main we keep runs to avoid cancelling release-relevant pipelines.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-changes:
     name: Check for Go changes
@@ -86,8 +92,22 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      - name: Verify go.mod and go.sum are tidy
+        run: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo "::error::go.mod or go.sum is not tidy. Run 'go mod tidy' locally and commit the changes."
+            exit 1
+          fi
+
       - name: Run tests
-        run: go test -v ./...
+        run: go test -v -count=1 ./...
 
       - name: Run tests with race detection
-        run: go test -race -v ./...
+        run: go test -race -v -count=1 ./...
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-file: go.mod
+          check-latest: true

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -34,6 +34,11 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded lint runs on the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   run-lint:
     permissions:
@@ -59,8 +64,8 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CHECKOV: false
           VALIDATE_YAML: false
-          VALIDATE_GO: false
-          VALIDATE_GO_MODULES: false # Go linting handled by go-tests.yml workflow
+          # Go linting via golangci-lint using .github/linters/.golangci.yml
+          VALIDATE_GO_MODULES: false # Avoid duplicate runs across modules
           VALIDATE_JAVASCRIPT_ES: false # Disable ESLint in favor of Biome
           VALIDATE_JSX: false
           VALIDATE_TSX: false # Disable ESLint in favor of Biome


### PR DESCRIPTION
Apply best practices from CI hardening review:

- Add concurrency blocks to cancel superseded PR runs (saves CI minutes on force-pushes); kept always-run on main branch pushes
- Add 'go mod tidy' drift check to go-tests.yml
- Add '-count=1' to test commands for deterministic CI runs
- Add govulncheck step using golang/govulncheck-action to detect vulnerabilities in dependencies and stdlib
- Re-enable Go linting in super-linter (golangci-lint with existing .github/linters/.golangci.yml configuration)

Workflows touched:
  - go-tests.yml
  - super-linter.yml
  - frontend-tests.yml
  - e2e-tests.yml