### PR TITLE
chore: upgrade Go to 1.26.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ BENCH_TIME ?= 5s
 BENCH_TIMEOUT ?= 30m
 BENCH_PATTERN ?= .
 GO_OLD ?= 1.25.6
-GO_NEW ?= 1.26
+GO_NEW ?= 1.26.2
 
 .PHONY: benchmark
 benchmark: ## Run Go benchmarks locally

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OpenFero/openfero
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674

--- a/hack/benchmark.dockerfile
+++ b/hack/benchmark.dockerfile
@@ -6,9 +6,9 @@
 #
 # Usage:
 #   docker build --build-arg GO_VERSION=1.25.6 -t openfero-bench:go1.25.6 -f hack/benchmark.dockerfile .
-#   docker build --build-arg GO_VERSION=1.26 -t openfero-bench:go1.26 -f hack/benchmark.dockerfile .
+#   docker build --build-arg GO_VERSION=1.26.2 -t openfero-bench:go1.26.2 -f hack/benchmark.dockerfile .
 
-ARG GO_VERSION=1.25.6
+ARG GO_VERSION=1.26.2
 
 FROM golang:${GO_VERSION}-bookworm
 


### PR DESCRIPTION
Bump Go version from 1.25.5 to 1.26.2 (latest stable patch release). Verified locally with govulncheck — fixes 8 stdlib vulnerabilities present in 1.25.x:

- GO-2026-4337 (crypto/tls: unexpected session resumption)
- GO-2026-4601 (net/url: incorrect IPv6 host literal parsing)
- and 6 additional stdlib advisories

Changes:
- go.mod: go directive 1.25.5 -> 1.26.2
- hack/benchmark.dockerfile: default GO_VERSION 1.25.6 -> 1.26.2
- Makefile: GO_NEW default 1.26 -> 1.26.2

CI uses 'go-version-file: go.mod' so all workflows pick this up automatically. No source changes required.