### PR TITLE
refactor: migrate logging from zap to log/slog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/swaggo/files/v2 v2.0.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.32.0 // indirect
@@ -72,7 +71,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_golang v1.23.2
 	github.com/swaggo/http-swagger/v2 v2.0.2
-	go.uber.org/zap v1.27.1
+	go.uber.org/zap v1.27.1 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	operariusv1alpha1 "github.com/OpenFero/openfero/api/v1alpha1"
@@ -19,7 +18,6 @@ import (
 	"github.com/OpenFero/openfero/pkg/services"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
-	"go.uber.org/zap"
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,17 +38,7 @@ var (
 
 // initLogger initializes the logger with the given log level
 func initLogger(logLevel string) error {
-	var cfg zap.Config
-	switch strings.ToLower(logLevel) {
-	case "debug":
-		cfg = zap.NewDevelopmentConfig()
-	case "info":
-		cfg = zap.NewProductionConfig()
-	default:
-		return fmt.Errorf("invalid log level specified: %s", logLevel)
-	}
-
-	return log.SetConfig(cfg)
+	return log.SetLevel(logLevel)
 }
 
 // validateAuthConfig validates the authentication configuration
@@ -113,7 +101,7 @@ func main() {
 		log.Fatal("Could not set log configuration")
 	}
 
-	log.Info("Starting OpenFero", zap.String("version", version), zap.String("commit", commit), zap.String("date", date))
+	log.Info("Starting OpenFero", "version", version, "commit", commit, "date", date)
 
 	// Initialize the appropriate alert store based on configuration
 	var store alertstore.Store
@@ -126,11 +114,11 @@ func main() {
 
 	// Initialize the alert store
 	if err := store.Initialize(); err != nil {
-		log.Fatal("Failed to initialize alert store", zap.String("error", err.Error()))
+		log.Fatal("Failed to initialize alert store", "error", err)
 	}
 	defer func() {
 		if err := store.Close(); err != nil {
-			log.Error("Failed to close alert store", zap.Error(err))
+			log.Error("Failed to close alert store", "error", err)
 		}
 	}()
 
@@ -140,7 +128,7 @@ func main() {
 	// Get current namespace if not specified
 	currentNamespace, err := kubernetes.GetCurrentNamespace()
 	if err != nil {
-		log.Fatal("Current kubernetes namespace could not be found", zap.String("error", err.Error()))
+		log.Fatal("Current kubernetes namespace could not be found", "error", err)
 	}
 
 	// Set operarius namespace to current namespace if not specified
@@ -163,13 +151,13 @@ func main() {
 
 	// Validate authentication configuration
 	if authErr := validateAuthConfig(authConfig); authErr != nil {
-		log.Fatal("Invalid authentication configuration", zap.Error(authErr))
+		log.Fatal("Invalid authentication configuration", "error", authErr)
 	}
 
 	// Log authentication configuration (without sensitive data)
 	if authConfig.Method != handlers.AuthMethodNone {
 		log.Info("Authentication enabled for webhook endpoint",
-			zap.String("method", string(authConfig.Method)))
+			"method", string(authConfig.Method))
 	} else {
 		log.Info("No authentication configured for webhook endpoint")
 	}
@@ -183,11 +171,11 @@ func main() {
 
 	// Initialize Operarius CRD support
 	log.Info("Initializing Operarius CRD support",
-		zap.String("namespace", *operariusNamespace))
+		"namespace", *operariusNamespace)
 
 	operariusClient, err := kubernetes.NewOperariusClient(kubeconfig, *operariusNamespace)
 	if err != nil {
-		log.Fatal("Failed to create Operarius client", zap.Error(err))
+		log.Fatal("Failed to create Operarius client", "error", err)
 	}
 
 	// Initialize informer and wait for cache sync
@@ -195,7 +183,7 @@ func main() {
 	_, err = operariusClient.InitOperariusInformer(ctx)
 	if err != nil {
 		log.Warn("Failed to initialize Operarius informer, falling back to API calls",
-			zap.Error(err))
+			"error", err)
 		metadata.OperariusSyncErrorsTotal.Inc()
 	}
 
@@ -212,7 +200,7 @@ func main() {
 			"openfero.io/managed-by": "openfero",
 		},
 	}
-	log.Info("Using Operarius job selector", zap.String("selector", metav1.FormatLabelSelector(jobSelector)))
+	log.Info("Using Operarius job selector", "selector", metav1.FormatLabelSelector(jobSelector))
 
 	// Initialize Job informer with update callback
 	// We watch jobs in the same namespace as Operarius CRDs
@@ -225,17 +213,17 @@ func main() {
 				operarius, err := operariusService.GetOperarius(ctx, operariusName, newJob.Namespace)
 				if err != nil {
 					log.Error("Failed to get Operarius for job update",
-						zap.String("operarius", operariusName),
-						zap.Error(err))
+						"operarius", operariusName,
+						"error", err)
 					return
 				}
 
 				// Update status based on job status
 				if err := operariusService.UpdateOperariusStatusFromJob(ctx, operarius, newJob); err != nil {
 					log.Error("Failed to update Operarius status from job",
-						zap.String("operarius", operariusName),
-						zap.String("job", newJob.Name),
-						zap.Error(err))
+						"operarius", operariusName,
+						"job", newJob.Name,
+						"error", err)
 				}
 			}
 		}
@@ -273,7 +261,7 @@ func main() {
 	http.HandleFunc("GET /startupz", server.StartupzGetHandler)
 	http.HandleFunc("GET /alertStore", func(w http.ResponseWriter, r *http.Request) {
 		log.Warn("Deprecated: /alertStore endpoint is deprecated, use /api/alerts instead",
-			zap.String("remoteAddr", r.RemoteAddr))
+			"remoteAddr", r.RemoteAddr)
 		server.AlertStoreGetHandler(w, r)
 	})
 	http.HandleFunc("GET /alerts", server.AlertsGetHandler)
@@ -309,6 +297,6 @@ func main() {
 
 	log.Info("Starting server on " + *addr)
 	if err := srv.ListenAndServe(); err != nil {
-		log.Fatal("error starting server: ", zap.String("error", err.Error()))
+		log.Fatal("error starting server", "error", err)
 	}
 }

--- a/pkg/alertstore/memberlist/memberlist.go
+++ b/pkg/alertstore/memberlist/memberlist.go
@@ -13,7 +13,6 @@ import (
 	"github.com/OpenFero/openfero/pkg/alertstore"
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/hashicorp/memberlist"
-	"go.uber.org/zap"
 )
 
 // MemberlistStore implements the alertstore.Store interface using memberlist
@@ -47,8 +46,8 @@ func NewMemberlistStore(clustername string, limit int) *MemberlistStore {
 	}
 
 	log.Debug("Creating new memberlist store",
-		zap.String("clusterName", clustername),
-		zap.Int("alertLimit", limit))
+		"clusterName", clustername,
+		"alertLimit", limit)
 
 	store := &MemberlistStore{
 		alerts: make([]alertEntry, 0, limit),
@@ -73,12 +72,12 @@ func (s *MemberlistStore) Initialize() error {
 	config.Events = s.delegate
 
 	log.Debug("Initializing memberlist with config",
-		zap.String("hostname", hostname))
+		"hostname", hostname)
 
 	// Create memberlist first
 	ml, err := memberlist.Create(config)
 	if err != nil {
-		log.Error("Failed to create memberlist", zap.Error(err))
+		log.Error("Failed to create memberlist", "error", err)
 		return fmt.Errorf("failed to create memberlist: %w", err)
 	}
 
@@ -105,34 +104,34 @@ func (s *MemberlistStore) Initialize() error {
 		namespaceData, readErr := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 		if readErr == nil {
 			namespace = string(namespaceData)
-			log.Debug("Discovered namespace from service account", zap.String("namespace", namespace))
+			log.Debug("Discovered namespace from service account", "namespace", namespace)
 		} else {
 			namespace = "default"
-			log.Debug("Using default namespace", zap.Error(readErr))
+			log.Debug("Using default namespace", "error", readErr)
 		}
 	}
 
 	// Form the service DNS name for Kubernetes
 	serviceDNS := fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace)
 	log.Info("Trying to join memberlist cluster",
-		zap.String("service", serviceDNS),
-		zap.String("namespace", namespace))
+		"service", serviceDNS,
+		"namespace", namespace)
 
 	// Try joining the cluster
 	joinCount, err := s.ml.Join([]string{serviceDNS})
 	if err != nil {
 		log.Warn("Failed to join cluster, creating new cluster",
-			zap.Error(err),
-			zap.String("serviceDNS", serviceDNS))
+			"error", err,
+			"serviceDNS", serviceDNS)
 		// This is not a fatal error - this node will form its own cluster
 		// that others can join later
 	} else {
-		log.Info("Successfully joined cluster", zap.Int("nodesJoined", joinCount))
+		log.Info("Successfully joined cluster", "nodesJoined", joinCount)
 	}
 
 	log.Info("Memberlist store initialized",
-		zap.Int("members", s.ml.NumMembers()),
-		zap.String("localNode", s.ml.LocalNode().Name))
+		"members", s.ml.NumMembers(),
+		"localNode", s.ml.LocalNode().Name)
 	return nil
 }
 
@@ -152,8 +151,8 @@ func (s *MemberlistStore) SaveAlertWithJobInfo(alert alertstore.Alert, status st
 
 	alertName := alert.Labels["alertname"]
 	log.Debug("Saving alert to memberlist store",
-		zap.String("alertname", alertName),
-		zap.String("status", status))
+		"alertname", alertName,
+		"status", status)
 
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
@@ -164,15 +163,15 @@ func (s *MemberlistStore) SaveAlertWithJobInfo(alert alertstore.Alert, status st
 	// Keep list at or under limit
 	if len(s.alerts) > s.limit {
 		s.alerts = s.alerts[:s.limit]
-		log.Debug("Trimmed alerts to limit", zap.Int("limit", s.limit))
+		log.Debug("Trimmed alerts to limit", "limit", s.limit)
 	}
 
 	// Broadcast the new alert to other nodes if memberlist is initialized
 	data, err := json.Marshal(entry)
 	if err != nil {
 		log.Error("Failed to marshal alert for broadcast",
-			zap.Error(err),
-			zap.String("alertname", alertName))
+			"error", err,
+			"alertname", alertName)
 		return fmt.Errorf("failed to marshal alert: %w", err)
 	}
 
@@ -182,11 +181,11 @@ func (s *MemberlistStore) SaveAlertWithJobInfo(alert alertstore.Alert, status st
 			notify: nil,
 		})
 		log.Debug("Broadcast alert to cluster",
-			zap.String("alertname", alertName),
-			zap.Int("clusterSize", s.ml.NumMembers()))
+			"alertname", alertName,
+			"clusterSize", s.ml.NumMembers())
 	} else {
 		log.Debug("Skipping broadcast - memberlist not initialized",
-			zap.String("alertname", alertName))
+			"alertname", alertName)
 	}
 
 	return nil
@@ -198,9 +197,9 @@ func (s *MemberlistStore) GetAlerts(query string, limit int) ([]alertstore.Alert
 	defer s.mutex.RUnlock()
 
 	log.Debug("Getting alerts from store",
-		zap.String("query", query),
-		zap.Int("requestedLimit", limit),
-		zap.Int("totalAlerts", len(s.alerts)))
+		"query", query,
+		"requestedLimit", limit,
+		"totalAlerts", len(s.alerts))
 
 	if limit <= 0 || limit > len(s.alerts) {
 		limit = len(s.alerts)
@@ -217,7 +216,7 @@ func (s *MemberlistStore) GetAlerts(query string, limit int) ([]alertstore.Alert
 				JobInfo:   s.alerts[i].JobInfo,
 			})
 		}
-		log.Debug("Returning alerts with no query filter", zap.Int("resultCount", len(result)))
+		log.Debug("Returning alerts with no query filter", "resultCount", len(result))
 		return result, nil
 	}
 
@@ -240,8 +239,8 @@ func (s *MemberlistStore) GetAlerts(query string, limit int) ([]alertstore.Alert
 	}
 
 	log.Debug("Returning filtered alerts",
-		zap.String("query", query),
-		zap.Int("resultCount", len(result)))
+		"query", query,
+		"resultCount", len(result))
 	return result, nil
 }
 
@@ -249,8 +248,8 @@ func (s *MemberlistStore) GetAlerts(query string, limit int) ([]alertstore.Alert
 func (s *MemberlistStore) Close() error {
 	if s.ml != nil {
 		log.Info("Leaving memberlist cluster",
-			zap.String("node", s.ml.LocalNode().Name),
-			zap.Int("clusterSize", s.ml.NumMembers()))
+			"node", s.ml.LocalNode().Name,
+			"clusterSize", s.ml.NumMembers())
 		return s.ml.Leave(time.Second * 5)
 	}
 	log.Debug("No memberlist to close")
@@ -312,16 +311,16 @@ func (d *delegate) NotifyMsg(data []byte) {
 	var entry alertEntry
 	if err := json.Unmarshal(data, &entry); err != nil {
 		log.Error("Failed to unmarshal alert in NotifyMsg",
-			zap.Error(err),
-			zap.Int("dataLength", len(data)))
+			"error", err,
+			"dataLength", len(data))
 		return
 	}
 
 	alertName := entry.Alert.Labels["alertname"]
 	log.Debug("Received alert notification from cluster",
-		zap.String("alertname", alertName),
-		zap.String("status", entry.Status),
-		zap.Time("timestamp", entry.Timestamp))
+		"alertname", alertName,
+		"status", entry.Status,
+		"timestamp", entry.Timestamp)
 
 	// Add the alert to our local store
 	if d.store == nil {
@@ -340,8 +339,8 @@ func (d *delegate) NotifyMsg(data []byte) {
 				if newAlertname, ok2 := entry.Alert.Labels["alertname"]; ok2 && alertname == newAlertname {
 					// Already have this alert, skip it
 					log.Debug("Skipping duplicate alert",
-						zap.String("alertname", alertname),
-						zap.Time("timestamp", entry.Timestamp))
+							"alertname", alertname,
+							"timestamp", entry.Timestamp)
 					return
 				}
 			}
@@ -355,7 +354,7 @@ func (d *delegate) NotifyMsg(data []byte) {
 	if len(d.store.alerts) > d.store.limit {
 		d.store.alerts = d.store.alerts[:d.store.limit]
 		log.Debug("Trimmed alerts to limit after receiving new alert",
-			zap.Int("limit", d.store.limit))
+			"limit", d.store.limit)
 	}
 }
 
@@ -380,15 +379,15 @@ func (d *delegate) LocalState(join bool) []byte {
 	data, err := json.Marshal(d.store.alerts)
 	if err != nil {
 		log.Error("Failed to marshal local state",
-			zap.Error(err),
-			zap.Int("alertCount", len(d.store.alerts)),
-			zap.Bool("joinOperation", join))
+			"error", err,
+			"alertCount", len(d.store.alerts),
+			"joinOperation", join)
 		return []byte{}
 	}
 	log.Debug("Sending local state to remote node",
-		zap.Int("alertCount", len(d.store.alerts)),
-		zap.Bool("joinOperation", join),
-		zap.Int("dataBytes", len(data)))
+		"alertCount", len(d.store.alerts),
+		"joinOperation", join,
+		"dataBytes", len(data))
 	return data
 }
 
@@ -405,19 +404,19 @@ func (d *delegate) MergeRemoteState(buf []byte, join bool) {
 	}
 
 	log.Debug("Merging remote state",
-		zap.Int("bufferSize", len(buf)),
-		zap.Bool("joinOperation", join))
+		"bufferSize", len(buf),
+		"joinOperation", join)
 
 	var remoteAlerts []alertEntry
 	if err := json.Unmarshal(buf, &remoteAlerts); err != nil {
 		log.Error("Failed to unmarshal remote state",
-			zap.Error(err),
-			zap.Int("bufferSize", len(buf)))
+			"error", err,
+			"bufferSize", len(buf))
 		return
 	}
 
 	log.Debug("Unmarshalled remote alerts",
-		zap.Int("remoteAlertCount", len(remoteAlerts)))
+		"remoteAlertCount", len(remoteAlerts))
 
 	d.store.mutex.Lock()
 	defer d.store.mutex.Unlock()
@@ -446,8 +445,8 @@ func (d *delegate) MergeRemoteState(buf []byte, join bool) {
 
 	if newAlertCount > 0 {
 		log.Debug("Added new alerts from remote state",
-			zap.Int("newAlerts", newAlertCount),
-			zap.Int("totalAlerts", len(d.store.alerts)))
+			"newAlerts", newAlertCount,
+			"totalAlerts", len(d.store.alerts))
 	}
 
 	// Sort by timestamp (newest first)
@@ -460,8 +459,8 @@ func (d *delegate) MergeRemoteState(buf []byte, join bool) {
 		oldLength := len(d.store.alerts)
 		d.store.alerts = d.store.alerts[:d.store.limit]
 		log.Debug("Trimmed alerts to limit after merge",
-			zap.Int("limit", d.store.limit),
-			zap.Int("removed", oldLength-d.store.limit))
+			"limit", d.store.limit,
+			"removed", oldLength-d.store.limit)
 	}
 }
 
@@ -474,10 +473,10 @@ func (d *delegate) NotifyJoin(node *memberlist.Node) {
 	}
 
 	log.Info("Node joined the cluster",
-		zap.String("node", node.Name),
-		zap.String("address", node.Address()),
-		zap.Uint8("state", uint8(node.State)),
-		zap.Int("clusterSize", clusterSize))
+		"node", node.Name,
+		"address", node.Address(),
+		"state", uint8(node.State),
+		"clusterSize", clusterSize)
 }
 
 // NotifyLeave is invoked when a node leaves the cluster
@@ -489,18 +488,18 @@ func (d *delegate) NotifyLeave(node *memberlist.Node) {
 	}
 
 	log.Info("Node left the cluster",
-		zap.String("node", node.Name),
-		zap.String("address", node.Address()),
-		zap.Uint8("state", uint8(node.State)),
-		zap.Int("clusterSize", clusterSize))
+		"node", node.Name,
+		"address", node.Address(),
+		"state", uint8(node.State),
+		"clusterSize", clusterSize)
 }
 
 // NotifyUpdate is invoked when a node's metadata is updated
 func (d *delegate) NotifyUpdate(node *memberlist.Node) {
 	log.Debug("Node metadata updated",
-		zap.String("node", node.Name),
-		zap.String("address", node.Address()),
-		zap.Uint8("state", uint8(node.State)))
+		"node", node.Name,
+		"address", node.Address(),
+		"state", uint8(node.State))
 }
 
 // broadcast implements the memberlist.Broadcast interface

--- a/pkg/alertstore/memory/memory_bench_test.go
+++ b/pkg/alertstore/memory/memory_bench_test.go
@@ -6,14 +6,11 @@ import (
 
 	"github.com/OpenFero/openfero/pkg/alertstore"
 	log "github.com/OpenFero/openfero/pkg/logging"
-	"go.uber.org/zap"
 )
 
 func init() {
 	// Initialize logger for benchmarks and suppress debug logging to avoid I/O noise
-	cfg := zap.NewProductionConfig()
-	cfg.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
-	_ = log.SetConfig(cfg)
+	_ = log.SetLevel("error")
 }
 
 func benchmarkAlertEntry(alertName string) alertstore.Alert {

--- a/pkg/handlers/api_about.go
+++ b/pkg/handlers/api_about.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	log "github.com/OpenFero/openfero/pkg/logging"
-	"go.uber.org/zap"
 )
 
 // BuildInfo contains information about the build
@@ -36,12 +35,12 @@ func SetBuildInfo(version, commit, date string) {
 // @Router /api/about [get]
 func AboutAPIHandler(w http.ResponseWriter, r *http.Request) {
 	log.Debug("Processing about API request",
-		zap.String("path", r.URL.Path),
-		zap.String("method", r.Method))
+		"path", r.URL.Path,
+		"method", r.Method)
 
 	w.Header().Set(ContentTypeHeader, ApplicationJSONVal)
 	if err := json.NewEncoder(w).Encode(buildInformation); err != nil {
-		log.Error("Failed to encode build info", zap.Error(err))
+		log.Error("Failed to encode build info", "error", err)
 		http.Error(w, "", http.StatusInternalServerError)
 		return
 	}

--- a/pkg/handlers/api_alerts.go
+++ b/pkg/handlers/api_alerts.go
@@ -15,7 +15,6 @@ import (
 	"github.com/OpenFero/openfero/pkg/models"
 	"github.com/OpenFero/openfero/pkg/services"
 	"github.com/OpenFero/openfero/pkg/utils"
-	"go.uber.org/zap"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -40,7 +39,7 @@ func (s *Server) AlertsGetHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(ContentTypeHeader, ApplicationJSONVal)
 
 	if err := json.NewEncoder(w).Encode("OK"); err != nil {
-		log.Error("error encoding messages: ", zap.String("error", err.Error()))
+		log.Error("error encoding messages: ", "error", err.Error())
 	}
 }
 
@@ -49,13 +48,13 @@ func (s *Server) AlertsPostHandler(w http.ResponseWriter, r *http.Request) {
 	dec := json.NewDecoder(r.Body)
 	defer func() {
 		if err := r.Body.Close(); err != nil {
-			log.Error("Failed to close request body", zap.Error(err))
+			log.Error("Failed to close request body", "error", err)
 		}
 	}()
 
 	message := models.HookMessage{}
 	if err := dec.Decode(&message); err != nil {
-		log.Error("error decoding message: ", zap.String("error", err.Error()))
+		log.Error("error decoding message: ", "error", err.Error())
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -65,9 +64,9 @@ func (s *Server) AlertsPostHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Use zap's fields for structured logging instead of string concatenation
 	log.Debug("Webhook received",
-		zap.String("status", status),
-		zap.Int("alertCount", alertcount),
-		zap.String("groupKey", message.GroupKey))
+		"status", status,
+		"alertCount", alertcount,
+		"groupKey", message.GroupKey)
 
 	if !services.CheckAlertStatus(status) {
 		log.Warn("Status of alert was neither firing nor resolved, stop creating a response job.")
@@ -85,40 +84,40 @@ func (s *Server) AlertsPostHandler(w http.ResponseWriter, r *http.Request) {
 // handleOperariusBasedJobs handles job creation using Operarius CRDs
 func (s *Server) handleOperariusBasedJobs(ctx context.Context, hookMessage models.HookMessage) {
 	log.Debug("Processing webhook with Operarius CRDs",
-		zap.String("status", hookMessage.Status),
-		zap.String("groupKey", hookMessage.GroupKey),
-		zap.Int("alertCount", len(hookMessage.Alerts)))
+		"status", hookMessage.Status,
+		"groupKey", hookMessage.GroupKey,
+		"alertCount", len(hookMessage.Alerts))
 
 	var jobInfo *alertstore.JobInfo
 
 	operarii, err := s.OperariusService.GetOperariiForNamespace(ctx, "")
 	if err != nil {
-		log.Error("Failed to get Operarii", zap.Error(err))
+		log.Error("Failed to get Operarii", "error", err)
 		// Continue to store alert even if we can't get Operarii
 	} else {
 		// Find matching Operarius
 		operarius, err := s.OperariusService.FindMatchingOperarius(hookMessage, operarii)
 		if err != nil {
-			log.Info("No matching Operarius found - alert will be stored without remediation", zap.Error(err))
+			log.Info("No matching Operarius found - alert will be stored without remediation", "error", err)
 		} else {
 			log.Info("Found matching Operarius",
-				zap.String("operarius", operarius.Name),
-				zap.String("namespace", operarius.Namespace),
-				zap.Int32("priority", operarius.Spec.Priority))
+				"operarius", operarius.Name,
+				"namespace", operarius.Namespace,
+				"priority", operarius.Spec.Priority)
 
 			// Check deduplication
 			shouldCreate, err := s.OperariusService.CheckDeduplication(ctx, operarius, hookMessage)
 			if err != nil {
-				log.Error("Failed to check deduplication", zap.Error(err))
+				log.Error("Failed to check deduplication", "error", err)
 			} else if !shouldCreate {
 				log.Info("Skipping job creation due to deduplication",
-					zap.String("operarius", operarius.Name),
-					zap.String("groupKey", hookMessage.GroupKey))
+					"operarius", operarius.Name,
+					"groupKey", hookMessage.GroupKey)
 
 				if err := s.OperariusService.UpdateOperariusDedupStatus(ctx, operarius); err != nil {
 					log.Warn("Failed to update Operarius dedup status",
-						zap.Error(err),
-						zap.String("operarius", operarius.Name))
+						"error", err,
+						"operarius", operarius.Name)
 				}
 
 				var lastExecutionTime *time.Time
@@ -142,22 +141,22 @@ func (s *Server) handleOperariusBasedJobs(ctx context.Context, hookMessage model
 				job, err := s.OperariusService.CreateJobFromOperarius(ctx, operarius, hookMessage)
 				if err != nil {
 					log.Error("Failed to create job from Operarius",
-						zap.Error(err),
-						zap.String("operarius", operarius.Name))
+						"error", err,
+						"operarius", operarius.Name)
 					metadata.JobsFailedTotal.Inc()
 				} else {
 
 					log.Info("Successfully created remediation job",
-						zap.String("jobName", job.Name),
-						zap.String("operarius", operarius.Name),
-						zap.String("namespace", job.Namespace),
-						zap.String("groupKey", hookMessage.GroupKey))
+						"jobName", job.Name,
+						"operarius", operarius.Name,
+						"namespace", job.Namespace,
+						"groupKey", hookMessage.GroupKey)
 
 					// Update Operarius status with execution info
 					if err := s.OperariusService.UpdateOperariusStatus(ctx, operarius, job.Name); err != nil {
 						log.Warn("Failed to update Operarius status",
-							zap.Error(err),
-							zap.String("operarius", operarius.Name))
+							"error", err,
+							"operarius", operarius.Name)
 						// Don't return - job was created successfully, status update is best-effort
 					}
 
@@ -210,7 +209,7 @@ func (s *Server) AlertStoreGetHandler(w http.ResponseWriter, r *http.Request) {
 
 	alerts, err := s.AlertStore.GetAlerts(query, limit)
 	if err != nil {
-		log.Error("Error retrieving alerts", zap.Error(err))
+		log.Error("Error retrieving alerts", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -239,8 +238,8 @@ func (s *Server) AlertStoreGetHandler(w http.ResponseWriter, r *http.Request) {
 			} else {
 				// Job might be deleted or error
 				log.Debug("Failed to get job for alert",
-					zap.String("job", alerts[i].JobInfo.JobName),
-					zap.Error(err))
+					"job", alerts[i].JobInfo.JobName,
+					"error", err)
 			}
 		}
 	}
@@ -248,7 +247,7 @@ func (s *Server) AlertStoreGetHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(ContentTypeHeader, ApplicationJSONVal)
 	err = json.NewEncoder(w).Encode(alerts)
 	if err != nil {
-		log.Error("Error encoding alerts", zap.Error(err))
+		log.Error("Error encoding alerts", "error", err)
 		http.Error(w, "", http.StatusInternalServerError)
 	}
 }

--- a/pkg/handlers/api_health.go
+++ b/pkg/handlers/api_health.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	log "github.com/OpenFero/openfero/pkg/logging"
-	"go.uber.org/zap"
 )
 
 // HealthzGetHandler handles health status requests
@@ -15,7 +14,7 @@ import (
 // @Success 200 {string} string "ok"
 // @Router /healthz [get]
 func (s *Server) HealthzGetHandler(w http.ResponseWriter, r *http.Request) {
-	log.Debug("Health check requested", zap.String("path", r.URL.Path))
+	log.Debug("Health check requested", "path", r.URL.Path)
 	w.Header().Set(ContentTypeHeader, "text/plain")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok"))
@@ -29,7 +28,7 @@ func (s *Server) HealthzGetHandler(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {string} string "ok"
 // @Router /readiness [get]
 func (s *Server) ReadinessGetHandler(w http.ResponseWriter, r *http.Request) {
-	log.Debug("Readiness check requested", zap.String("path", r.URL.Path))
+	log.Debug("Readiness check requested", "path", r.URL.Path)
 	w.Header().Set(ContentTypeHeader, "text/plain")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("ok"))
@@ -44,7 +43,7 @@ func (s *Server) ReadinessGetHandler(w http.ResponseWriter, r *http.Request) {
 // @Failure 503 {string} string "starting"
 // @Router /startupz [get]
 func (s *Server) StartupzGetHandler(w http.ResponseWriter, r *http.Request) {
-	log.Debug("Startup check requested", zap.String("path", r.URL.Path))
+	log.Debug("Startup check requested", "path", r.URL.Path)
 	w.Header().Set(ContentTypeHeader, "text/plain")
 	if !s.StartupComplete.Load() {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/pkg/handlers/api_health_test.go
+++ b/pkg/handlers/api_health_test.go
@@ -7,13 +7,10 @@ import (
 "testing"
 
 "github.com/OpenFero/openfero/pkg/logging"
-"go.uber.org/zap"
 )
 
 func TestMain(m *testing.M) {
-	cfg := zap.NewDevelopmentConfig()
-	cfg.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
-	if err := logging.SetConfig(cfg); err != nil {
+	if err := logging.SetLevel("warn"); err != nil {
 		os.Exit(1)
 	}
 	os.Exit(m.Run())

--- a/pkg/handlers/api_jobs.go
+++ b/pkg/handlers/api_jobs.go
@@ -7,7 +7,6 @@ import (
 
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/OpenFero/openfero/pkg/models"
-	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,9 +19,9 @@ import (
 // @Router /api/jobs [get]
 func (s *Server) JobsAPIHandler(w http.ResponseWriter, r *http.Request) {
 	log.Debug("Processing jobs API request",
-		zap.String("path", r.URL.Path),
-		zap.String("method", r.Method),
-		zap.String("remoteAddr", r.RemoteAddr))
+		"path", r.URL.Path,
+		"method", r.Method,
+		"remoteAddr", r.RemoteAddr)
 
 	var jobInfos []models.JobInfo
 
@@ -30,9 +29,9 @@ func (s *Server) JobsAPIHandler(w http.ResponseWriter, r *http.Request) {
 		// Fetch Operarii
 		operarii, err := s.OperariusService.GetOperariiForNamespace(r.Context(), "")
 		if err != nil {
-			log.Error("Failed to get Operarii", zap.Error(err))
+			log.Error("Failed to get Operarii", "error", err)
 		} else {
-			log.Debug("Retrieved Operarii", zap.Int("count", len(operarii)))
+			log.Debug("Retrieved Operarii", "count", len(operarii))
 			for _, op := range operarii {
 				image := "unknown"
 				if len(op.Spec.JobTemplate.Spec.Template.Spec.Containers) > 0 {
@@ -84,6 +83,6 @@ func (s *Server) JobsAPIHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set(ContentTypeHeader, ApplicationJSONVal)
 	if err := json.NewEncoder(w).Encode(jobInfos); err != nil {
-		log.Error("Failed to encode jobs response", zap.Error(err))
+		log.Error("Failed to encode jobs response", "error", err)
 	}
 }

--- a/pkg/handlers/frontend_spa.go
+++ b/pkg/handlers/frontend_spa.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	log "github.com/OpenFero/openfero/pkg/logging"
-	"go.uber.org/zap"
 )
 
 // FrontendFS holds the embedded Vue.js frontend files
@@ -26,7 +25,7 @@ func NewFrontendHandler(frontendFS embed.FS) http.Handler {
 	// Get the dist subdirectory from the embedded filesystem
 	distFS, err := fs.Sub(frontendFS, "frontend/dist")
 	if err != nil {
-		log.Error("Failed to get frontend dist subdirectory", zap.Error(err))
+		log.Error("Failed to get frontend dist subdirectory", "error", err)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Frontend not available", http.StatusInternalServerError)
 		})
@@ -35,7 +34,7 @@ func NewFrontendHandler(frontendFS embed.FS) http.Handler {
 	// Read index.html for SPA fallback
 	indexHTML, err := fs.ReadFile(distFS, "index.html")
 	if err != nil {
-		log.Error("Failed to read index.html", zap.Error(err))
+		log.Error("Failed to read index.html", "error", err)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Frontend not available", http.StatusInternalServerError)
 		})
@@ -56,8 +55,8 @@ func (h *frontendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Debug("Frontend request",
-		zap.String("path", urlPath),
-		zap.String("method", r.Method))
+		"path", urlPath,
+		"method", r.Method)
 
 	// Check if this is an API route (should not be handled here)
 	if isAPIRoute(urlPath) {
@@ -75,7 +74,7 @@ func (h *frontendHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(ContentTypeHeader, "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	if _, err := w.Write(h.indexHTML); err != nil {
-		log.Error("Failed to write index.html", zap.Error(err))
+		log.Error("Failed to write index.html", "error", err)
 	}
 }
 

--- a/pkg/handlers/middleware_auth.go
+++ b/pkg/handlers/middleware_auth.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	log "github.com/OpenFero/openfero/pkg/logging"
-	"go.uber.org/zap"
 )
 
 // AuthMethod represents the type of authentication method
@@ -47,17 +46,16 @@ func AuthMiddleware(config AuthConfig) func(http.HandlerFunc) http.HandlerFunc {
 				authenticated, authMethod = authenticateBearer(r, config.BearerToken)
 
 			default:
-				log.Warn("Unknown authentication method", zap.String("method", string(config.Method)))
+				log.Warn("Unknown authentication method", "method", string(config.Method))
 				http.Error(w, "Internal server error", http.StatusInternalServerError)
 				return
 			}
 
 			if !authenticated {
 				log.Warn("Authentication failed",
-					zap.String("method", authMethod),
-					zap.String("remoteAddr", r.RemoteAddr),
-					zap.String("userAgent", r.UserAgent()))
-
+				"method", authMethod,
+				"remoteAddr", r.RemoteAddr,
+				"userAgent", r.UserAgent())
 				// Set appropriate WWW-Authenticate header
 				switch config.Method {
 				case AuthMethodBasic:
@@ -70,8 +68,8 @@ func AuthMiddleware(config AuthConfig) func(http.HandlerFunc) http.HandlerFunc {
 			}
 
 			log.Debug("Authentication successful",
-				zap.String("method", authMethod),
-				zap.String("remoteAddr", r.RemoteAddr))
+				"method", authMethod,
+				"remoteAddr", r.RemoteAddr)
 
 			next(w, r)
 		}

--- a/pkg/handlers/realtime_ws.go
+++ b/pkg/handlers/realtime_ws.go
@@ -9,7 +9,6 @@ import (
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/OpenFero/openfero/pkg/models"
 	"github.com/gorilla/websocket"
-	"go.uber.org/zap"
 )
 
 const (
@@ -88,7 +87,7 @@ func (h *WSHub) run() {
 			h.mu.Lock()
 			h.clients[client] = struct{}{}
 			h.mu.Unlock()
-			log.Debug("WebSocket client connected", zap.Int("totalClients", len(h.clients)))
+			log.Debug("WebSocket client connected", "totalClients", len(h.clients))
 
 		case client := <-h.unregister:
 			h.mu.Lock()
@@ -97,7 +96,7 @@ func (h *WSHub) run() {
 				close(client.send)
 			}
 			h.mu.Unlock()
-			log.Debug("WebSocket client disconnected", zap.Int("totalClients", len(h.clients)))
+			log.Debug("WebSocket client disconnected", "totalClients", len(h.clients))
 
 		case message := <-h.broadcast:
 			h.mu.RLock()
@@ -120,7 +119,7 @@ func (h *WSHub) Broadcast(msgType string, data any) {
 	msg := WSMessage{Type: msgType, Data: data}
 	jsonData, err := json.Marshal(msg)
 	if err != nil {
-		log.Error("Failed to marshal WebSocket message", zap.Error(err))
+		log.Error("Failed to marshal WebSocket message", "error", err)
 		return
 	}
 	h.broadcast <- jsonData
@@ -149,7 +148,7 @@ func (c *WSClient) readPump() {
 		_, _, err := c.conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				log.Debug("WebSocket read error", zap.Error(err))
+				log.Debug("WebSocket read error", "error", err)
 			}
 			break
 		}
@@ -209,7 +208,7 @@ func (c *WSClient) writePump() {
 func WebSocketHandler(w http.ResponseWriter, r *http.Request) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Error("WebSocket upgrade failed", zap.Error(err))
+		log.Error("WebSocket upgrade failed", "error", err)
 		return
 	}
 
@@ -227,7 +226,7 @@ func WebSocketHandler(w http.ResponseWriter, r *http.Request) {
 	client.send <- jsonData
 
 	log.Debug("WebSocket client connected",
-		zap.String("remoteAddr", r.RemoteAddr))
+		"remoteAddr", r.RemoteAddr)
 
 	// Start read and write pumps in goroutines
 	go client.writePump()

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/OpenFero/openfero/pkg/metadata"
-	"go.uber.org/zap"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -32,7 +31,7 @@ func InitKubeClient(kubeconfig *string) *kubernetes.Clientset {
 	// Try in-cluster config first
 	config, err = rest.InClusterConfig()
 	if err != nil {
-		log.Debug("In-cluster configuration not available, trying kubeconfig file", zap.Error(err))
+		log.Debug("In-cluster configuration not available, trying kubeconfig file", "error", err)
 
 		kubeconfigPath := *kubeconfig
 		if kubeconfigPath == "" {
@@ -47,16 +46,16 @@ func InitKubeClient(kubeconfig *string) *kubernetes.Clientset {
 		// Use kubeconfig file
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 		if err != nil {
-			log.Fatal("Could not create k8s configuration", zap.Error(err))
+			log.Fatal("Could not create k8s configuration", "error", err)
 		}
-		log.Info("Using kubeconfig file for cluster access", zap.String("kubeconfigPath", kubeconfigPath))
+		log.Info("Using kubeconfig file for cluster access", "kubeconfigPath", kubeconfigPath)
 	} else {
 		log.Info("Using in-cluster configuration")
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.Fatal("Could not create k8s client", zap.Error(err))
+		log.Fatal("Could not create k8s client", "error", err)
 	}
 
 	return clientset
@@ -102,8 +101,8 @@ func InitJobInformer(clientset *kubernetes.Clientset, jobDestinationNamespace st
 	)
 
 	log.Debug("Initializing Job informer",
-		zap.String("namespace", jobDestinationNamespace),
-		zap.String("labelSelector", metav1.FormatLabelSelector(labelSelector)))
+		"namespace", jobDestinationNamespace,
+		"labelSelector", metav1.FormatLabelSelector(labelSelector))
 
 	// Get Job informer
 	jobInformer := jobFactory.Batch().V1().Jobs().Informer()
@@ -112,7 +111,7 @@ func InitJobInformer(clientset *kubernetes.Clientset, jobDestinationNamespace st
 	if _, err := jobInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			job := obj.(*batchv1.Job)
-			log.Debug("Job added", zap.String("job", job.Name), zap.String("namespace", job.Namespace))
+			log.Debug("Job added", "job", job.Name, "namespace", job.Namespace)
 			metadata.JobsCreatedTotal.Inc()
 			if updateFunc != nil {
 				updateFunc(nil, job)
@@ -122,11 +121,11 @@ func InitJobInformer(clientset *kubernetes.Clientset, jobDestinationNamespace st
 			oldJob := old.(*batchv1.Job)
 			newJob := new.(*batchv1.Job)
 			if newJob.Status.Succeeded > 0 && oldJob.Status.Succeeded == 0 {
-				log.Debug("Job completed successfully", zap.String("job", newJob.Name), zap.String("namespace", newJob.Namespace))
+				log.Debug("Job completed successfully", "job", newJob.Name, "namespace", newJob.Namespace)
 				metadata.JobsSucceededTotal.Inc()
 			}
 			if newJob.Status.Failed > 0 && oldJob.Status.Failed == 0 {
-				log.Debug("Job failed", zap.String("job", newJob.Name), zap.String("namespace", newJob.Namespace))
+				log.Debug("Job failed", "job", newJob.Name, "namespace", newJob.Namespace)
 				metadata.JobsFailedTotal.Inc()
 			}
 			if updateFunc != nil {
@@ -135,10 +134,10 @@ func InitJobInformer(clientset *kubernetes.Clientset, jobDestinationNamespace st
 		},
 		DeleteFunc: func(obj any) {
 			job := obj.(*batchv1.Job)
-			log.Debug("Job deleted", zap.String("job", job.Name), zap.String("namespace", job.Namespace))
+			log.Debug("Job deleted", "job", job.Name, "namespace", job.Namespace)
 		},
 	}); err != nil {
-		log.Fatal("Failed to add Job event handler", zap.Error(err))
+		log.Fatal("Failed to add Job event handler", "error", err)
 	}
 
 	// Start informer
@@ -146,9 +145,9 @@ func InitJobInformer(clientset *kubernetes.Clientset, jobDestinationNamespace st
 
 	// Wait for cache sync
 	if !cache.WaitForCacheSync(context.Background().Done(), jobInformer.HasSynced) {
-		log.Fatal("Failed to sync Job cache", zap.String("namespace", jobDestinationNamespace))
+		log.Fatal("Failed to sync Job cache", "namespace", jobDestinationNamespace)
 	}
-	log.Info("Job cache synced", zap.String("namespace", jobDestinationNamespace))
+	log.Info("Job cache synced", "namespace", jobDestinationNamespace)
 
 	return jobInformer.GetStore()
 }

--- a/pkg/kubernetes/operarius.go
+++ b/pkg/kubernetes/operarius.go
@@ -10,7 +10,6 @@ import (
 	operariusv1alpha1 "github.com/OpenFero/openfero/api/v1alpha1"
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/OpenFero/openfero/pkg/metadata"
-	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -151,9 +150,9 @@ func (c *OperariusClient) InitOperariusInformer(ctx context.Context) (cache.Stor
 			operarius, ok := obj.(*operariusv1alpha1.Operarius)
 			if ok {
 				log.Debug("Operarius added to store",
-					zap.String("name", operarius.Name),
-					zap.String("namespace", operarius.Namespace),
-					zap.String("alertname", operarius.Spec.AlertSelector.AlertName))
+					"name", operarius.Name,
+					"namespace", operarius.Namespace,
+					"alertname", operarius.Spec.AlertSelector.AlertName)
 				metadata.OperariusItemsLoaded.Inc()
 			}
 		},
@@ -166,16 +165,16 @@ func (c *OperariusClient) InitOperariusInformer(ctx context.Context) (cache.Stor
 					return
 				}
 				log.Debug("Operarius updated in store",
-					zap.String("name", newOp.Name),
-					zap.String("namespace", newOp.Namespace))
+					"name", newOp.Name,
+					"namespace", newOp.Namespace)
 			}
 		},
 		DeleteFunc: func(obj any) {
 			operarius, ok := obj.(*operariusv1alpha1.Operarius)
 			if ok {
 				log.Debug("Operarius removed from store",
-					zap.String("name", operarius.Name),
-					zap.String("namespace", operarius.Namespace))
+					"name", operarius.Name,
+					"namespace", operarius.Namespace)
 				metadata.OperariusItemsLoaded.Dec()
 			}
 		},
@@ -189,7 +188,7 @@ func (c *OperariusClient) InitOperariusInformer(ctx context.Context) (cache.Stor
 
 	// Wait for cache sync
 	log.Info("Waiting for Operarius cache to sync",
-		zap.String("namespace", c.namespace))
+		"namespace", c.namespace)
 
 	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -200,8 +199,8 @@ func (c *OperariusClient) InitOperariusInformer(ctx context.Context) (cache.Stor
 
 	c.store = c.informer.GetStore()
 	log.Info("Operarius cache synced",
-		zap.String("namespace", c.namespace),
-		zap.Int("count", len(c.store.List())))
+		"namespace", c.namespace,
+		"count", len(c.store.List()))
 
 	return c.store, nil
 }
@@ -272,8 +271,8 @@ func (c *OperariusClient) UpdateStatus(ctx context.Context, operarius *operarius
 	}
 
 	log.Debug("Updated Operarius status",
-		zap.String("name", operarius.Name),
-		zap.Int32("executionCount", operarius.Status.ExecutionCount))
+		"name", operarius.Name,
+		"executionCount", operarius.Status.ExecutionCount)
 
 	return nil
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,44 +1,54 @@
 package logging
 
 import (
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"log/slog"
+	"os"
 )
 
-var zapLog *zap.Logger
+// Level constants matching the levels used across the codebase.
+const (
+	LevelDebug = slog.LevelDebug
+	LevelInfo  = slog.LevelInfo
+	LevelWarn  = slog.LevelWarn
+	LevelError = slog.LevelError
+)
 
-// SetConfig sets the logger configuration
-func SetConfig(config zap.Config) error {
-	var err error
-	encoderConfig := zap.NewProductionEncoderConfig()
-	encoderConfig.StacktraceKey = "" // to hide stacktrace info
-	encoderConfig.TimeKey = "timestamp"
-	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder // format timestamp to ISO8601
-	config.EncoderConfig = encoderConfig
-	config.Encoding = "json" // set encoding to JSON
-	zapLog, err = config.Build(zap.AddCallerSkip(1))
-	if err != nil {
-		return err
+var level = new(slog.LevelVar) // default: Info
+
+// SetLevel configures the minimum log level ("debug" or "info").
+func SetLevel(logLevel string) error {
+	switch logLevel {
+	case "debug":
+		level.Set(slog.LevelDebug)
+	default:
+		level.Set(slog.LevelInfo)
 	}
+	h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level:     level,
+		AddSource: true,
+	})
+	slog.SetDefault(slog.New(h))
 	return nil
 }
 
-func Info(message string, fields ...zap.Field) {
-	zapLog.Info(message, fields...)
+func Info(message string, args ...any) {
+	slog.Info(message, args...)
 }
 
-func Debug(message string, fields ...zap.Field) {
-	zapLog.Debug(message, fields...)
+func Debug(message string, args ...any) {
+	slog.Debug(message, args...)
 }
 
-func Warn(message string, fields ...zap.Field) {
-	zapLog.Warn(message, fields...)
+func Warn(message string, args ...any) {
+	slog.Warn(message, args...)
 }
 
-func Error(message string, fields ...zap.Field) {
-	zapLog.Error(message, fields...)
+func Error(message string, args ...any) {
+	slog.Error(message, args...)
 }
 
-func Fatal(message string, fields ...zap.Field) {
-	zapLog.Fatal(message, fields...)
+// Fatal logs at Error level and exits with code 1.
+func Fatal(message string, args ...any) {
+	slog.Error(message, args...)
+	os.Exit(1)
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 )
 
 const (
@@ -134,12 +133,12 @@ func AddMetricsToPrometheusRegistry() {
 func getMetricsOptions(metric metrics.Description) prometheus.Opts {
 	tokens := strings.Split(metric.Name, "/")
 	if len(tokens) < 2 {
-		log.Error("error getting metric options: invalid metric name", zap.String("metric", metric.Name))
+			log.Error("error getting metric options: invalid metric name", "metric", metric.Name)
 		return prometheus.Opts{}
 	}
 	nameTokens := strings.Split(tokens[len(tokens)-1], ":")
 	if len(nameTokens) < 2 {
-		log.Error("error getting metric options: invalid metric name format", zap.String("metric", metric.Name))
+			log.Error("error getting metric options: invalid metric name format", "metric", metric.Name)
 		return prometheus.Opts{}
 	}
 	// create a unique name for metric, that will be its primary key on the registry

--- a/pkg/services/alert.go
+++ b/pkg/services/alert.go
@@ -4,7 +4,6 @@ import (
 	"github.com/OpenFero/openfero/pkg/alertstore"
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/OpenFero/openfero/pkg/models"
-	"go.uber.org/zap"
 )
 
 // AlertBroadcastFunc is a callback function for broadcasting alert updates
@@ -44,17 +43,17 @@ func CheckAlertStatus(status string) bool {
 // SaveAlert saves an alert to the alertstore
 func SaveAlert(alertStore alertstore.Store, alert models.Alert, status string) {
 	log.Debug("Saving alert in alert store",
-		zap.String("alertname", alert.Labels["alertname"]),
-		zap.String("status", status))
+		"alertname", alert.Labels["alertname"],
+		"status", status)
 
 	// Convert to alertstore.Alert type
 	storeAlert := alert.ToAlertStoreAlert()
 	err := alertStore.SaveAlert(storeAlert, status)
 	if err != nil {
 		log.Error("Failed to save alert",
-			zap.String("alertname", alert.Labels["alertname"]),
-			zap.String("status", status),
-			zap.Error(err))
+			"alertname", alert.Labels["alertname"],
+			"status", status,
+			"error", err)
 		return
 	}
 
@@ -65,18 +64,18 @@ func SaveAlert(alertStore alertstore.Store, alert models.Alert, status string) {
 // SaveAlertWithJobInfo saves an alert to the alertstore with job information
 func SaveAlertWithJobInfo(alertStore alertstore.Store, alert models.Alert, status string, jobInfo *alertstore.JobInfo) {
 	log.Debug("Saving alert in alert store with job info",
-		zap.String("alertname", alert.Labels["alertname"]),
-		zap.String("status", status),
-		zap.String("jobName", jobInfo.JobName))
+		"alertname", alert.Labels["alertname"],
+		"status", status,
+		"jobName", jobInfo.JobName)
 
 	// Convert to alertstore.Alert type
 	storeAlert := alert.ToAlertStoreAlert()
 	err := alertStore.SaveAlertWithJobInfo(storeAlert, status, jobInfo)
 	if err != nil {
 		log.Error("Failed to save alert with job info",
-			zap.String("alertname", alert.Labels["alertname"]),
-			zap.String("status", status),
-			zap.Error(err))
+			"alertname", alert.Labels["alertname"],
+			"status", status,
+			"error", err)
 		return
 	}
 

--- a/pkg/services/alert_bench_test.go
+++ b/pkg/services/alert_bench_test.go
@@ -7,14 +7,11 @@ import (
 	"github.com/OpenFero/openfero/pkg/alertstore/memory"
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/OpenFero/openfero/pkg/models"
-	"go.uber.org/zap"
 )
 
 func init() {
 	// Suppress debug logging in benchmarks to avoid I/O noise
-	cfg := zap.NewProductionConfig()
-	cfg.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
-	_ = log.SetConfig(cfg)
+	_ = log.SetLevel("error")
 }
 
 func benchmarkAlertStoreAlert(alertName string) models.Alert {

--- a/pkg/services/operarius.go
+++ b/pkg/services/operarius.go
@@ -20,7 +20,6 @@ import (
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/OpenFero/openfero/pkg/models"
 	"github.com/OpenFero/openfero/pkg/utils"
-	"go.uber.org/zap"
 )
 
 // OperariusClientInterface defines the interface for Operarius client operations
@@ -368,7 +367,7 @@ func (s *OperariusService) GetOperariiForNamespace(ctx context.Context, namespac
 	if err != nil {
 		// Fallback to cache if API call fails (e.g., network issues)
 		log.Warn("Failed to list Operarii from API, trying cache",
-			zap.Error(err))
+			"error", err)
 		operarii, err = s.operariusClient.List()
 		if err != nil {
 			return nil, fmt.Errorf("failed to list Operarii: %w", err)
@@ -376,8 +375,8 @@ func (s *OperariusService) GetOperariiForNamespace(ctx context.Context, namespac
 	}
 
 	log.Debug("Retrieved Operarii",
-		zap.String("namespace", namespace),
-		zap.Int("count", len(operarii)))
+		"namespace", namespace,
+		"count", len(operarii))
 
 	return operarii, nil
 }
@@ -398,7 +397,7 @@ func (s *OperariusService) UpdateOperariusDedupStatus(ctx context.Context, opera
 	}
 
 	log.Debug("Updated Operarius dedup status",
-		zap.String("operarius", operarius.Name))
+		"operarius", operarius.Name)
 
 	return nil
 }
@@ -423,9 +422,9 @@ func (s *OperariusService) UpdateOperariusStatus(ctx context.Context, operarius 
 	}
 
 	log.Info("Updated Operarius status",
-		zap.String("operarius", operarius.Name),
-		zap.String("jobName", jobName),
-		zap.Int32("executionCount", operarius.Status.ExecutionCount))
+		"operarius", operarius.Name,
+		"jobName", jobName,
+		"executionCount", operarius.Status.ExecutionCount)
 
 	if s.broadcaster != nil {
 		s.broadcaster(*operarius)
@@ -477,9 +476,9 @@ func (s *OperariusService) UpdateOperariusStatusFromJob(ctx context.Context, ope
 	}
 
 	log.Info("Updated Operarius status from job",
-		zap.String("operarius", operarius.Name),
-		zap.String("job", job.Name),
-		zap.String("status", newStatus))
+		"operarius", operarius.Name,
+		"job", job.Name,
+		"status", newStatus)
 
 	if s.broadcaster != nil {
 		s.broadcaster(*operarius)

--- a/pkg/services/operarius_test.go
+++ b/pkg/services/operarius_test.go
@@ -18,16 +18,11 @@ import (
 	log "github.com/OpenFero/openfero/pkg/logging"
 	"github.com/OpenFero/openfero/pkg/models"
 	"github.com/OpenFero/openfero/pkg/utils"
-	"go.uber.org/zap"
 )
 
 func init() {
 	// Initialize logger for tests
-	cfg := zap.NewDevelopmentConfig()
-	err := log.SetConfig(cfg)
-	if err != nil {
-		panic(err)
-	}
+	_ = log.SetLevel("debug")
 }
 
 // Verify MockOperariusClient implements OperariusClientInterface


### PR DESCRIPTION
Replace go.uber.org/zap with the standard log/slog package (Go 1.21+). The pkg/logging wrapper retains the same function signatures but now uses slog internally with JSON output and source location. All call sites are updated from zap field constructors (zap.String, zap.Error, zap.Int, etc.) to slog-style "key", value pairs.
